### PR TITLE
Test listener code

### DIFF
--- a/mixmatch/listener.py
+++ b/mixmatch/listener.py
@@ -122,22 +122,25 @@ class ImageDeleteEndpoint(object):
         delete(ResourceMapping.find("images", payload['id']))
 
 
+def get_endpoints_for_sp(sp_name):
+    return [
+            VolumeCreateEndpoint(sp_name),
+            VolumeDeleteEndpoint(sp_name),
+            SnapshotCreateEndpoint(sp_name),
+            SnapshotDeleteEndpoint(sp_name),
+            ImageCreateEndpoint(sp_name),
+            ImageDeleteEndpoint(sp_name)
+    ]
+
+
 def get_server_for_sp(sp):
     cfg = config.get_conf_for_sp(sp)
-    endpoints = [
-            VolumeCreateEndpoint(cfg.sp_name),
-            VolumeDeleteEndpoint(cfg.sp_name),
-            SnapshotCreateEndpoint(cfg.sp_name),
-            SnapshotDeleteEndpoint(cfg.sp_name),
-            ImageCreateEndpoint(cfg.sp_name),
-            ImageDeleteEndpoint(cfg.sp_name)
-    ]
     transport = oslo_messaging.get_notification_transport(CONF, cfg.messagebus)
     targets = [oslo_messaging.Target(topic='notifications')]
     return oslo_messaging.get_notification_listener(
             transport,
             targets,
-            endpoints,
+            get_endpoints_for_sp(cfg.sp_name),
             executor='eventlet')
 
 

--- a/mixmatch/model.py
+++ b/mixmatch/model.py
@@ -39,6 +39,15 @@ class ResourceMapping(BASE):
     def __repr__(self):
         return str((self.resource_type, self.resource_id, self.resource_sp))
 
+    def __eq__(self, other):
+        return (self.resource_type == other.resource_type and
+                self.resource_id == other.resource_id and
+                self.resource_sp == other.resource_sp and
+                self.tenant_id == other.tenant_id)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @classmethod
     def find(cls, resource_type, resource_id):
         context = enginefacade.transaction_context()

--- a/mixmatch/tests/unit/test_listener.py
+++ b/mixmatch/tests/unit/test_listener.py
@@ -1,0 +1,160 @@
+#   Copyright 2016 Massachusetts Open Cloud
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+from testtools import testcase
+from oslo_messaging.notify import dispatcher as notify_dispatcher
+import mock
+
+from mixmatch.model import ResourceMapping
+from mixmatch.listener import get_endpoints_for_sp
+
+
+class TestListener(testcase.TestCase):
+    @mock.patch('mixmatch.listener.insert')
+    def test_create_volume(self, insert):
+        endpoints = get_endpoints_for_sp('default')
+        dispatcher = notify_dispatcher.NotificationDispatcher(
+            endpoints, serializer=None)
+        MESSAGE = {
+          'payload': {
+            'volume_id': "1232123212321",
+            'tenant_id': "abdbabdbabdba"
+          },
+          'priority': 'info',
+          'publisher_id': 'volume.node4',
+          'event_type': 'volume.create.start',
+          'timestamp': '2014-03-03 18:21:04.369234',
+          'message_id': '99863dda-97f0-443a-a0c1-6ed317b7fd45'
+        }
+        incoming = mock.Mock(ctxt={}, message=MESSAGE)
+        dispatcher.dispatch(incoming)
+        insert.assert_called_with(
+            ResourceMapping('volumes',
+                            '1232123212321',
+                            'abdbabdbabdba',
+                            'default'))
+
+    @mock.patch('mixmatch.listener.ResourceMapping.find', return_value=35)
+    @mock.patch('mixmatch.listener.delete')
+    def test_delete_volume(self, delete, find):
+        endpoints = get_endpoints_for_sp('default')
+        dispatcher = notify_dispatcher.NotificationDispatcher(
+            endpoints, serializer=None)
+        MESSAGE = {
+          'payload': {
+            'volume_id': "1232123212321",
+            'tenant_id': "abdbabdbabdba"
+          },
+          'priority': 'info',
+          'publisher_id': 'volume.node4',
+          'event_type': 'volume.delete.end',
+          'timestamp': '2014-03-03 18:21:04.369234',
+          'message_id': '99863dda-97f0-443a-a0c1-6ed317b7fd45'
+        }
+        incoming = mock.Mock(ctxt={}, message=MESSAGE)
+        dispatcher.dispatch(incoming)
+        find.assert_called_with('volumes', '1232123212321')
+        delete.assert_called_with(35)
+
+    @mock.patch('mixmatch.listener.insert')
+    def test_create_snapshot(self, insert):
+        endpoints = get_endpoints_for_sp('default')
+        dispatcher = notify_dispatcher.NotificationDispatcher(
+            endpoints, serializer=None)
+        MESSAGE = {
+          'payload': {
+            'snapshot_id': "1232123212321",
+            'tenant_id': "abdbabdbabdba"
+          },
+          'priority': 'info',
+          'publisher_id': 'snapshot.node4',
+          'event_type': 'snapshot.create.start',
+          'timestamp': '2014-03-03 18:21:04.369234',
+          'message_id': '99863dda-97f0-443a-a0c1-6ed317b7fd45'
+        }
+        incoming = mock.Mock(ctxt={}, message=MESSAGE)
+        dispatcher.dispatch(incoming)
+        insert.assert_called_with(
+            ResourceMapping('snapshots',
+                            '1232123212321',
+                            'abdbabdbabdba',
+                            'default'))
+
+    @mock.patch('mixmatch.listener.ResourceMapping.find', return_value=35)
+    @mock.patch('mixmatch.listener.delete')
+    def test_delete_snapshot(self, delete, find):
+        endpoints = get_endpoints_for_sp('default')
+        dispatcher = notify_dispatcher.NotificationDispatcher(
+            endpoints, serializer=None)
+        MESSAGE = {
+          'payload': {
+            'snapshot_id': "1232123212321",
+            'tenant_id': "abdbabdbabdba"
+          },
+          'priority': 'info',
+          'publisher_id': 'snapshot.node4',
+          'event_type': 'snapshot.delete.end',
+          'timestamp': '2014-03-03 18:21:04.369234',
+          'message_id': '99863dda-97f0-443a-a0c1-6ed317b7fd45'
+        }
+        incoming = mock.Mock(ctxt={}, message=MESSAGE)
+        dispatcher.dispatch(incoming)
+        find.assert_called_with('snapshots', '1232123212321')
+        delete.assert_called_with(35)
+
+    @mock.patch('mixmatch.listener.insert')
+    def test_create_image(self, insert):
+        endpoints = get_endpoints_for_sp('default')
+        dispatcher = notify_dispatcher.NotificationDispatcher(
+            endpoints, serializer=None)
+        MESSAGE = {
+          'payload': {
+            'id': "1232123212321",
+            'owner': "abdbabdbabdba"
+          },
+          'priority': 'info',
+          'publisher_id': 'image.node4',
+          'event_type': 'image.create',
+          'timestamp': '2014-03-03 18:21:04.369234',
+          'message_id': '99863dda-97f0-443a-a0c1-6ed317b7fd45'
+        }
+        incoming = mock.Mock(ctxt={}, message=MESSAGE)
+        dispatcher.dispatch(incoming)
+        insert.assert_called_with(
+            ResourceMapping('images',
+                            '1232123212321',
+                            'abdbabdbabdba',
+                            'default'))
+
+    @mock.patch('mixmatch.listener.ResourceMapping.find', return_value=35)
+    @mock.patch('mixmatch.listener.delete')
+    def test_delete_image(self, delete, find):
+        endpoints = get_endpoints_for_sp('default')
+        dispatcher = notify_dispatcher.NotificationDispatcher(
+            endpoints, serializer=None)
+        MESSAGE = {
+          'payload': {
+            'id': "1232123212321",
+            'owner': "abdbabdbabdba"
+          },
+          'priority': 'info',
+          'publisher_id': 'image.node4',
+          'event_type': 'image.delete',
+          'timestamp': '2014-03-03 18:21:04.369234',
+          'message_id': '99863dda-97f0-443a-a0c1-6ed317b7fd45'
+        }
+        incoming = mock.Mock(ctxt={}, message=MESSAGE)
+        dispatcher.dispatch(incoming)
+        find.assert_called_with('images', '1232123212321')
+        delete.assert_called_with(35)


### PR DESCRIPTION
This code tests that the endpoints in listener.py are set up correctly, and
parse the arguments in notifications correctly.  It doesn't run against a real
database---if we change the code to call 'find' or 'delete' in a slightly
different way, the tests may need to change.  (Most likely, we might start
checking that the resource mapping found when deleting has the correct
arguments.)