### PR TITLE
fix for unversioned requests without action

### DIFF
--- a/etc/k2k-proxy.conf
+++ b/etc/k2k-proxy.conf
@@ -5,7 +5,7 @@ connection="sqlite:////home/ubuntu/proxy.db"
 auth_url="http://127.0.0.1:5000/v3"
 username="admin"
 user_domain_id="default"
-password="nomoresecret"
+password="nomoresecrete"
 project_name="admin"
 project_domain_id="default"
 
@@ -13,8 +13,10 @@ project_domain_id="default"
 aggregation=True
 token_caching=False
 search_by_broadcast=True
-service_providers=default
+service_providers=default, coffee-sp
 caching=True
+image_api_versions = v2.3, v2.2, v2.1, v2.0, v1.1, v1.0
+volume_api_versions = v3.0, v2.0, v1.0 
 
 [cache]
 enabled=True
@@ -27,19 +29,12 @@ auth_url="http://127.0.0.1:5000/v3"
 image_endpoint="http://localhost:9292"
 volume_endpoint="http://localhost:8776"
 
-[sp_os-sp1]
-sp_name=os-sp1
-messagebus="rabbit://stackrabbit:stackqueue@192.168.0.68"
-auth_url="http://192.168.0.68:5000/v3"
-image_endpoint="http://192.168.0.68:9292"
-volume_endpoint="http://192.168.0.68:8776"
-
-[sp_os-sp2]
-sp_name=os-sp2
-messagebus="rabbit://stackrabbit:stackqueue@192.168.0.69"
-auth_url="http://192.168.0.69:5000/v3"
-image_endpoint="http://192.168.0.69:9292"
-volume_endpoint="http://192.168.0.69:8776"
+[sp_coffee-sp]
+sp_name=coffee-sp
+messagebus="rabbit://stackrabbit:stackqueue@192.168.0.106"
+auth_url="http://192.168.0.106:5000/v3"
+image_endpoint="http://192.168.0.106:9292"
+volume_endpoint="http://192.168.0.106:8776"
 
 # Logging
 [loggers]

--- a/mixmatch/config.py
+++ b/mixmatch/config.py
@@ -50,7 +50,15 @@ proxy_opts = [
 
     cfg.IntOpt('cache_time',
                default=600,
-               help='How long to store cached tokens for')
+               help='How long to store cached tokens for'),
+
+    cfg.ListOpt('image_api_versions',
+                default=['v2.3', 'v2.2', 'v2.1', 'v2.0', 'v1.1', 'v1.0'],
+                help='List of supported image api versions'),
+
+    cfg.ListOpt('volume_api_versions',
+                default=['v3.0', 'v2.0', 'v1.0'],
+                help='List of supported volume api versions'),
 ]
 
 # Keystone

--- a/mixmatch/services.py
+++ b/mixmatch/services.py
@@ -35,7 +35,7 @@ def construct_url(service_provider, service_type,
             'version': version,
             'action': os.path.join(*action)
         }
-    elif service_type in ['volume', 'volumev2']:
+    elif service_type == 'volume':
         endpoint = conf.volume_endpoint
 
         return "%(endpoint)s/%(version)s/%(project)s/%(action)s" % {


### PR DESCRIPTION
- Handles only un-versioned requests to /volume and /image with no action. 
- #FIXME: need to update "updated" date and time if OS makes any changes to volume API.
- #TODO: move the new method _list_api_versions() to services.py, better?
- for _list_api_versions(), instead of hardcoding a template/example for the API list and update it, I recreated the list from scratch instead. Better or worse? 
