### PR TITLE
handle versioned calls with no action and test

### DIFF
--- a/mixmatch/proxy.py
+++ b/mixmatch/proxy.py
@@ -13,10 +13,11 @@
 #   under the License.
 
 import uuid
-import json
 
 import requests
 import flask
+
+from flask import abort
 
 from mixmatch import config
 from mixmatch.config import LOG, CONF
@@ -60,8 +61,8 @@ class RequestHandler:
             self._forward = self._list_api_versions
             return
         elif len(self.request_path) == 2:
-            # TODO verioned calls with no action
-            raise ValueError
+            # versioned calls with no action
+            abort(400)
 
         self.version = self.request_path[1]
 
@@ -219,74 +220,8 @@ class RequestHandler:
         )
 
     def _list_api_versions(self):
-        api_versions = list()
-
-        if self.service_type == 'image':
-            supported_versions = CONF.proxy.image_api_versions
-
-            for version in supported_versions:
-                info = dict()
-                if version == supported_versions[0]:
-                    info.update({'status': 'CURRENT'})
-                else:
-                    info.update({'status': 'SUPPORTED'})
-
-                info.update({
-                   'id':  version,
-                   'links': [
-                       {'href': '%s/%s/' % (request.base_url,
-                                            version[:-2]),
-                        'rel': 'self'}
-                   ]
-                })
-                api_versions.append(info)
-            return json.dumps({'versions': api_versions})
-
-        elif self.service_type == 'volume':
-            supported_versions = CONF.proxy.volume_api_versions
-
-            for version in supported_versions:
-                info = dict()
-                if version == supported_versions[0]:
-                    info.update({
-                        'status': 'CURRENT',
-                        'min_version': version[1:],
-                        'version': version[1:]
-                    })
-                else:
-                    info.update({
-                        'status': 'SUPPORTED',
-                        'min_version': '',
-                        'version': ''
-                    })
-
-                info.update({
-                    'id': version,
-                    'updated': '2014-06-28T12:20:21Z',  # FIXME
-                    'links': [
-                        {'href': 'http://docs.openstack.org/',
-                         'type': 'text/html',
-                         'rel': 'describedby'},
-                        {'href': '%s/%s/' % (request.base_url,
-                                             version[:-2]),
-                         'rel': 'self'}
-                    ],
-                    'media-types': [
-                        {'base': 'application/json',
-                         'type':
-                             'application/vnd.openstack.volume+json;version=%s'
-                                 % version[1:-2]},
-                        {'base': 'application/xml',
-                         'type':
-                             'application/vnd.openstack.volume+xml;version=%s'
-                                 % version[1:-2]}
-                    ]
-                })
-                api_versions.append(info)
-            return json.dumps({'versions': api_versions})
-
-        else:
-            raise ValueError
+        return services.list_api_versions(self.service_type,
+                                          request.base_url)
 
     def forward(self):
         return self._forward()

--- a/mixmatch/services.py
+++ b/mixmatch/services.py
@@ -108,6 +108,77 @@ def aggregate(responses, key, params=None, path=None, detailed=True):
     return json.dumps(response)
 
 
+def list_api_versions(service_type, url):
+    api_versions = list()
+
+    if service_type == 'image':
+        supported_versions = CONF.proxy.image_api_versions
+
+        for version in supported_versions:
+            info = dict()
+            if version == supported_versions[0]:
+                info.update({'status': 'CURRENT'})
+            else:
+                info.update({'status': 'SUPPORTED'})
+
+            info.update({
+               'id':  version,
+               'links': [
+                   {'href': '%s/%s/' % (url,
+                                        version[:-2]),
+                    'rel': 'self'}
+               ]
+            })
+            api_versions.append(info)
+        return json.dumps({'versions': api_versions})
+
+    elif service_type == 'volume':
+        supported_versions = CONF.proxy.volume_api_versions
+
+        for version in supported_versions:
+            info = dict()
+            if version == supported_versions[0]:
+                info.update({
+                    'status': 'CURRENT',
+                    'min_version': version[1:],
+                    'version': version[1:]
+                    })
+            else:
+                info.update({
+                    'status': 'SUPPORTED',
+                    'min_version': '',
+                    'version': ''
+                })
+
+            info.update({
+                'id': version,
+                'updated': '2014-06-28T12:20:21Z',  # FIXME
+                'links': [
+                    {'href': 'http://docs.openstack.org/',
+                     'type': 'text/html',
+                     'rel': 'describedby'},
+                    {'href': '%s/%s/' % (url,
+                                         version[:-2]),
+                     'rel': 'self'}
+                ],
+                'media-types': [
+                    {'base': 'application/json',
+                     'type':
+                         'application/vnd.openstack.volume+json;version=%s'
+                             % version[1:-2]},
+                    {'base': 'application/xml',
+                     'type':
+                         'application/vnd.openstack.volume+xml;version=%s'
+                             % version[1:-2]}
+                ]
+            })
+            api_versions.append(info)
+        return json.dumps({'versions': api_versions})
+
+    else:
+        raise ValueError
+
+
 def _is_reverse(order):
     """Return True if order is asc, False if order is desc"""
     if order == 'asc':

--- a/mixmatch/tests/unit/test_mocked.py
+++ b/mixmatch/tests/unit/test_mocked.py
@@ -315,3 +315,19 @@ class TestMock(testcase.TestCase):
         actual = json.loads(response.data.decode("ascii"))
         actual['images'].sort(key=(lambda x: x[u'id']))
         self.assertEqual(actual, EXPECTED)
+
+    def test_unversioned_calls_no_action(self):
+        response = self.app.get(
+            '/image',
+            headers={'X-AUTH-TOKEN': 'local-tok',
+                     'CONTENT-TYPE': 'application/json'})
+        self.assertEqual(response.status_code, 200)
+        actual = json.loads(response.data.decode("ascii"))
+        self.assertEqual(len(actual['versions']), 6)
+
+    def test_versioned_calls_no_action(self):
+        response = self.app.get(
+            '/image/v2',
+            headers={'X-AUTH-TOKEN': 'local-tok',
+                     'CONTENT-TYPE': 'application/json'})
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
- return 400 if the request provides a version but no action
- rearragement of list_api_versions(). Cleaner and easier to test. 
- added tests for handling unversioned/verioned calls with no action 
- added test for list_api_versions() 