### PR TITLE
Approach changed: automate running tempest tests and filter unexpected failures

### DIFF
--- a/tempest.sh
+++ b/tempest.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# navigate to tempest, run tests, and save to current_fail.txt
+cd /opt/stack/tempest
+./run_tempest.sh | grep FAILED > ~/current_fail.txt
+
+# navigate to home, clean the output (split and index), and save to current_fail_clean.txt
+cd ~
+cat current_fail.txt | tr -s ' ' | cut -d ' ' -f 2 > current_fail_clean.txt
+
+# compare the file of expected tests to current_fail_clean.txt and exit 
+if grep -Fxvf expected_fail.txt current_fail_clean.txt 
+   then
+      echo "unexpected failures"
+      exit 1 
+   else
+      echo "all expected failures"
+      exit 0
+fi 


### PR DESCRIPTION
Script to run all tempest tests, and compares the failed tests to the expected failures. This script assumes the file expected_fails.txt exists in the home directory (for now). 

To improve this: 
- indexing it differently if the failure is in SetUpClass (index 3 not 2) to show the test name. 
- overwrite service_providers in proxy configuration file to make it 'default' (local only). 
