### PR TITLE
fix for volumes aggregation in v1

### DIFF
--- a/mixmatch/proxy.py
+++ b/mixmatch/proxy.py
@@ -77,7 +77,8 @@ class RequestHandler:
             # if request is to /volumes, change it
             # to /volumes/detail for aggregation
             if self.method == 'GET' \
-                    and self.action[-1] == 'volumes':
+                    and self.action[-1] == 'volumes' \
+                    and not self.version == 'v1':
                 self.detailed = False
                 self.action.insert(len(self.action), 'detail')
         else:


### PR DESCRIPTION
tempest tests for volume listing in volumev1 failed because of a KeyError when trying _remove_details() in services.py. 
The tests didn't fail before, so I am trying to figure out what exactly changed in volumev1 headers that caused this error. 
For now: requests to /volumes need not to be changed to /volumes/detail in v1. 